### PR TITLE
Enable simultaneous multiple joysticks across multiple guis and swarmies

### DIFF
--- a/classifiers/CNN_9010_wAug_160.h5
+++ b/classifiers/CNN_9010_wAug_160.h5
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bcb2b50327a60c26a526e7132e1540703c7884602f5f9f9629f8008292c6375c
-size 248723000

--- a/launch/rover_gui.launch
+++ b/launch/rover_gui.launch
@@ -31,6 +31,7 @@
           - /rosout_agg
           - /tf
           - /tf_static
+          - /joy
         </rosparam>
       </node>
     </group >

--- a/launch/rover_gui.launch
+++ b/launch/rover_gui.launch
@@ -15,7 +15,9 @@
     <param name="startsim" value="$(arg startsim)"/>
     <param name="gazebo" value="$(arg gazebo)"/>
   </group>
-
+  
+  <node name="$(anon joy_node)" pkg="joy" type="joy_node" />
+  
   <node name="$(anon rqt_rover_gui)" pkg="rqt_gui" type="rqt_gui" args="-s rqt_rover_gui" required="True" output="screen">
     <env name="SWARMATHON_APP_ROOT" value="$(env PWD)" />
     <env name="GAZEBO_MODEL_PATH" value="$(env PWD)/simulation/models" />

--- a/src/rqt_rover_gui/launch/rover_gui.launch
+++ b/src/rqt_rover_gui/launch/rover_gui.launch
@@ -1,4 +1,4 @@
 <launch>
-<node name="joy_node" pkg="joy" type="joy_node" />
+<node name="$(anon joy_node)" pkg="joy" type="joy_node" />
 
 </launch>

--- a/src/rqt_rover_gui/src/rover_gui_plugin.cpp
+++ b/src/rqt_rover_gui/src/rover_gui_plugin.cpp
@@ -66,7 +66,6 @@ namespace rqt_rover_gui
     max_info_log_length = 10000;
     max_diag_log_length = 10000;
 
-    joy_process = NULL;
     joystickGripperInterface = NULL;
 
     obstacle_call_count = 0;
@@ -263,9 +262,6 @@ namespace rqt_rover_gui
     ui.all_autonomous_button->setStyleSheet("color: grey; border:2px solid grey; border-radius:12px; padding: 5px;");
     ui.all_stop_button->setStyleSheet("color: grey; border:2px solid grey; border-radius:12px; padding: 5px;");
 
-    //QString return_msg = startROSJoyNode();
-    //displayLogMessage(return_msg);
-
     info_log_subscriber = nh.subscribe("/infoLog", 10, &RoverGUIPlugin::infoLogMessageEventHandler, this);
     diag_log_subscriber = nh.subscribe("/diagsLog", 10, &RoverGUIPlugin::diagLogMessageEventHandler, this);
 
@@ -279,7 +275,6 @@ namespace rqt_rover_gui
     ui.map_frame->clear();
     clearSimulationButtonEventHandler();
     rover_poll_timer->stop();
-    stopROSJoyNode();
     ros::shutdown();
   }
 
@@ -1452,9 +1447,6 @@ void RoverGUIPlugin::autonomousRadioButtonEventHandler(bool marked)
     control_mode_publishers[selected_rover_name].publish(control_mode_msg);
     emit sendInfoLogMessage(QString::fromStdString(selected_rover_name)+" changed to autonomous control");
 
-    QString return_msg = stopROSJoyNode();
-    emit sendInfoLogMessage(return_msg);
-
     //Enable all stop button
     ui.all_stop_button->setEnabled(true);
     ui.all_stop_button->setStyleSheet("color: white; border:2px solid white; border-radius:12px; padding: 5px;");
@@ -1497,9 +1489,6 @@ void RoverGUIPlugin::joystickRadioButtonEventHandler(bool marked)
 
     control_mode_publishers[selected_rover_name].publish(control_mode_msg);
     emit sendInfoLogMessage(QString::fromStdString(selected_rover_name)+" changed to joystick control");\
-
-    QString return_msg = startROSJoyNode();
-    emit sendInfoLogMessage(return_msg);
 
     //Enable all autonomous button
     ui.all_autonomous_button->setEnabled(true);
@@ -2325,48 +2314,6 @@ void RoverGUIPlugin::visualizeSimulationButtonEventHandler()
         emit sendInfoLogMessage(return_msg);
     }
 
-}
-
-QString RoverGUIPlugin::startROSJoyNode()
-{
-    if (!joy_process)
-    {
-
-        QString argument = "rosrun joy joy_node __name:=joy_node$HOSTNAME";
-
-        joy_process = new QProcess();
-
-        joy_process->start("sh", QStringList() << "-c" << argument);
-
-       // joy_process->waitForStarted();
-
-        return "Started the joystick node.";
-
-    }
-    else
-    {
-        return "The joystick node is already running.";
-    }
-}
-
-QString RoverGUIPlugin::stopROSJoyNode()
-{
-   //return "Do nothing for debug";
-
-    if (joy_process)
-    {
-        joy_process->terminate();
-        joy_process->waitForFinished();
-        delete joy_process;
-        joy_process = NULL;
-
-        return "Stopped the running joystick node.";
-
-    }
-    else
-    {
-        return "Tried to stop the joystick node but it isn't running.";
-    }
 }
 
 QString RoverGUIPlugin::addUniformTargets()

--- a/src/rqt_rover_gui/src/rover_gui_plugin.cpp
+++ b/src/rqt_rover_gui/src/rover_gui_plugin.cpp
@@ -2332,7 +2332,7 @@ QString RoverGUIPlugin::startROSJoyNode()
     if (!joy_process)
     {
 
-        QString argument = "rosrun joy joy_node";
+        QString argument = "rosrun joy joy_node __name:=joy_node$HOSTNAME";
 
         joy_process = new QProcess();
 

--- a/src/swarmie/launch/swarmie.xml
+++ b/src/swarmie/launch/swarmie.xml
@@ -130,6 +130,8 @@
       <rosparam param="ignore_topics">
         - /tf
         - /tf_static
+        - /joy
+        - /joy/set_feedback
       </rosparam>
     </node>
 


### PR DESCRIPTION
- Removed joy_node call from GUI c++
- added joy_node to launch file and uses "anonymous"(hostname & rng) node name so you can have multiple running simultaneously
- added joy to ignored topics to stop crosstalk between GUIs and Swarmies 